### PR TITLE
Lägg till glömt lösenord och lösenordsåterställning

### DIFF
--- a/index.html
+++ b/index.html
@@ -250,6 +250,7 @@
                         <input id="loginPassword" type="password" data-t-placeholder="authPlaceholderPassword" placeholder="Ditt lösenord" style="width:100%; background:#1e293b; border:1px solid #334155; color:white; padding:12px; border-radius:6px; font-size:14px;" onkeydown="if(event.key==='Enter') handleLogin()">
                     </div>
                     <button id="loginSubmitBtn" class="btn" style="width:100%; margin-top:4px;" onclick="handleLogin()" data-t="authLoginSubmit">LOGGA IN</button>
+                    <button class="btn btn-secondary" style="width:100%; font-size:0.8rem; padding:8px;" onclick="showAuthView('forgot')" data-t="authForgotLink">Glömt lösenord?</button>
                     <div style="text-align:center; color:#475569; font-size:0.8rem; font-weight:bold; margin:4px 0;" data-t="authOr">ELLER</div>
                     <button class="btn btn-secondary" style="width:100%;" onclick="authSignInWithProvider('google')">Google</button>
                     <button class="btn btn-secondary" style="width:100%;" onclick="authSignInWithProvider('discord')">Discord</button>
@@ -277,6 +278,31 @@
                     <button class="btn btn-secondary" style="width:100%;" onclick="authSignInWithProvider('google')">Google</button>
                     <button class="btn btn-secondary" style="width:100%;" onclick="authSignInWithProvider('discord')">Discord</button>
                     <button class="btn btn-secondary" style="width:100%; margin-top:4px;" onclick="closeAuthModal()" data-t="authCancel">AVBRYT</button>
+                </div>
+            </div>
+
+            <!-- VY: Glömt lösenord -->
+            <div id="authView-forgot" class="hidden">
+                <div style="display:flex; flex-direction:column; gap:14px;">
+                    <h3 data-t="authForgotTitle" style="text-align:center; margin:0 0 6px; font-size:1rem; letter-spacing:1px;">ÅTERSTÄLL LÖSENORD</h3>
+                    <div>
+                        <label data-t="authEmailLabel" style="font-size:11px; font-weight:bold; color:#94a3b8; text-transform:uppercase; display:block; margin-bottom:4px;">E-POST</label>
+                        <input id="forgotEmail" type="email" data-t-placeholder="authPlaceholderEmail" placeholder="din@email.se" style="width:100%; background:#1e293b; border:1px solid #334155; color:white; padding:12px; border-radius:6px; font-size:14px;" onkeydown="if(event.key==='Enter') handleForgotPassword()">
+                    </div>
+                    <button id="forgotSubmitBtn" class="btn" style="width:100%;" onclick="handleForgotPassword()" data-t="authForgotSubmit">SKICKA LÄNK</button>
+                    <button class="btn btn-secondary" style="width:100%;" onclick="showAuthView('login')" data-t="authBackToLogin">← Tillbaka</button>
+                </div>
+            </div>
+
+            <!-- VY: Sätt nytt lösenord (efter reset-länk) -->
+            <div id="authView-reset" class="hidden">
+                <div style="display:flex; flex-direction:column; gap:14px;">
+                    <h3 data-t="authNewPasswordTitle" style="text-align:center; margin:0 0 6px; font-size:1rem; letter-spacing:1px;">NYTT LÖSENORD</h3>
+                    <div>
+                        <label data-t="authNewPasswordLabel" style="font-size:11px; font-weight:bold; color:#94a3b8; text-transform:uppercase; display:block; margin-bottom:4px;">NYTT LÖSENORD</label>
+                        <input id="resetPassword" type="password" data-t-placeholder="authPlaceholderNewPassword" placeholder="Välj ett nytt lösenord" style="width:100%; background:#1e293b; border:1px solid #334155; color:white; padding:12px; border-radius:6px; font-size:14px;" onkeydown="if(event.key==='Enter') handleUpdatePassword()">
+                    </div>
+                    <button id="resetSubmitBtn" class="btn" style="width:100%;" onclick="handleUpdatePassword()" data-t="authNewPasswordSubmit">SPARA LÖSENORD</button>
                 </div>
             </div>
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -88,7 +88,17 @@ const i18n = {
         authConfirmEmail: "✅ Konto skapat! Kolla din e-post för att bekräfta kontot.",
         authErrUsernameTaken: "Användarnamnet är redan taget.",
         authErrInvalid: "Felaktig e-post eller lösenord.",
-        authErrGeneric: "Något gick fel. Försök igen."
+        authErrGeneric: "Något gick fel. Försök igen.",
+        authForgotLink: "Glömt lösenord?",
+        authForgotTitle: "ÅTERSTÄLL LÖSENORD",
+        authForgotSubmit: "SKICKA LÄNK",
+        authForgotSuccess: "Länk skickad! Kolla din inbox – kan hamna i skräpposten.",
+        authNewPasswordTitle: "NYTT LÖSENORD",
+        authNewPasswordLabel: "NYTT LÖSENORD",
+        authPlaceholderNewPassword: "Välj ett nytt lösenord",
+        authNewPasswordSubmit: "SPARA LÖSENORD",
+        authNewPasswordSuccess: "Lösenord uppdaterat! Du är nu inloggad.",
+        authBackToLogin: "← Tillbaka"
     },
     en: {
         title: "SharpRunner", startBtn: "Start Game", statsBtn: "Statistics", aboutBtn: "About Us", settingsBtn: "Settings",
@@ -147,7 +157,17 @@ const i18n = {
         authConfirmEmail: "✅ Account created! Check your email to confirm.",
         authErrUsernameTaken: "Username is already taken.",
         authErrInvalid: "Invalid email or password.",
-        authErrGeneric: "Something went wrong. Please try again."
+        authErrGeneric: "Something went wrong. Please try again.",
+        authForgotLink: "Forgot password?",
+        authForgotTitle: "RESET PASSWORD",
+        authForgotSubmit: "SEND LINK",
+        authForgotSuccess: "Link sent! Check your inbox – it may end up in spam.",
+        authNewPasswordTitle: "NEW PASSWORD",
+        authNewPasswordLabel: "NEW PASSWORD",
+        authPlaceholderNewPassword: "Choose a new password",
+        authNewPasswordSubmit: "SAVE PASSWORD",
+        authNewPasswordSuccess: "Password updated! You are now logged in.",
+        authBackToLogin: "← Back"
     }
 };
 


### PR DESCRIPTION
Lägger till komplett password reset-flöde.

## Flöde
1. Användaren klickar "Glömt lösenord?" i login-vyn
2. Fyller i sin email → Supabase skickar reset-mail
3. Klickar länken i mailet → hamnar tillbaka i spelet
4. PASSWORD_RECOVERY-event öppnar "nytt lösenord"-vyn automatiskt
5. Användaren sätter nytt lösenord → inloggad direkt

## UI
- "Glömt lösenord?"-knapp under login-knappen
- Bekräftelsemeddelande med skräppost-varning
- Tillbaka-knapp till login-vyn