### PR TITLE
Uppdatera DEVLOG och lägg till fellogg 2026-02-26

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -5,6 +5,31 @@ Uppdateras i slutet av varje arbetspass av den som jobbat.
 
 ---
 
+## 2026-02-26 – Joakim (+ Claude Code)
+
+### Vad gjordes
+
+**Projektstruktur och verktyg:**
+- Skapade `Development errors.md` – fellogg som Claude automatiskt uppdaterar när problem identifieras eller löses under utvecklingens gång
+- Skapade GitHub issue #70 – plan för dev/prod-separering med lokal server och separat Supabase-projekt
+
+**GitHub project board:**
+- Lade till labels `FE` och `BE` på alla issues istället för separata projekt
+- Skapade 16 nya labels: `bug`, `blocked`, `needs-discussion`, `feature`, `improvement`, `documentation`, `auth`, `gameplay`, `ui`, `mobile`, `social`, `performance`, `prio`, `easy`, `medium`, `hard`
+- Applicerade relevanta labels på alla 18 öppna issues
+
+### Viktiga beslut
+- BE/FE-separation hanteras via labels, inte separata project boards – enklare att underhålla
+- `needs-discussion` kräver godkännande av båda (Joakim + Bozhidar) innan implementation
+- `blocked` ska alltid specificera vad issuen väntar på i issuens beskrivning
+
+### Nästa steg
+- Joakim skapar Supabase dev-projekt (`SharpRunner-dev`) manuellt – se issue #70
+- Felsök password reset – redirect fungerar men modal öppnas inte
+- Konfigurera Google och Discord OAuth i Supabase
+
+---
+
 ## 2026-02-25 (kväll) – Joakim (+ Claude Code)
 
 ### Vad gjordes

--- a/Development errors.md
+++ b/Development errors.md
@@ -1,0 +1,22 @@
+# Fellogg – SharpRunner
+
+Loggar fel och problem som uppstår under utvecklingens gång.
+Uppdateras automatiskt av Claude när problem identifieras eller löses.
+
+## Hur fel loggas
+
+När ett fel eller problem identifieras under utvecklingen lägger Claude till en ny post i denna fil.
+Varje post följer strukturen nedan. Status uppdateras allteftersom problemet utreds och åtgärdas.
+
+```
+## [Rubrik]
+
+**Datum:** ÅÅÅÅ-MM-DD
+**Händelse:** Vad som hände / vad som inte fungerade
+**Orsak:** Vad som orsakade problemet (om känd)
+**Åtgärd:** Vad som gjordes / PR-länk om relevant
+**Status:** Löst / Pågående / Okänd
+```
+
+---
+


### PR DESCRIPTION
## Summary
- Lägger till `Development errors.md` – fellogg som uppdateras automatiskt när fel uppstår under utvecklingen
- Uppdaterar DEVLOG med dagens arbete: labels, project board-omorganisering, issue #70

## Test plan
- [ ] Verifiera att `Development errors.md` syns i repot med korrekt struktur
- [ ] Verifiera att DEVLOG är korrekt uppdaterad

🤖 Generated with [Claude Code](https://claude.com/claude-code)